### PR TITLE
Refactor buffer size in file encryption process

### DIFF
--- a/FileEncryption/Form1.cs
+++ b/FileEncryption/Form1.cs
@@ -8,6 +8,8 @@ namespace FileEncryption
 {
     public partial class Form1 : Form
     {
+        private const int BufferSize = 8192;
+
         private string currentFilePath;
         private string currentKey;
         private bool isEncoding;
@@ -85,7 +87,7 @@ namespace FileEncryption
 
         private async Task ProcessFileStreamAsync(Stream inputStream, Stream outputStream, byte[] keyBytes, IProgress<int> progress)
         {
-            byte[] buffer = new byte[8192];
+            byte[] buffer = new byte[BufferSize];
             long totalBytes = inputStream.Length;
             long processedBytes = 0;
             int bytesRead;


### PR DESCRIPTION
Closes #13. Form1.cs - https://github.com/EvgeniyShpakovich/FileEncryption/blob/main/FileEncryption/Form1.cs
This pull request refactors the FileEncryption implementation by replacing the hardcoded magic number 8192 used for the buffer size in the ProcessFileStreamAsync method. The buffer size has been replaced with a named constant, improving code readability and maintainability.