### PR TITLE
Extract StartFileOperation Methods

### DIFF
--- a/FileEncryption/Form1.cs
+++ b/FileEncryption/Form1.cs
@@ -72,9 +72,11 @@ namespace FileEncryption
 
             bgWorker.RunWorkerAsync();
         }
-        private void EncryptFile(string filePath, string key, BackgroundWorker worker)
+
+        private void EncryptOrDecryptFile(string filePath, string key, BackgroundWorker worker)
         {
             byte[] keyBytes = Encoding.UTF8.GetBytes(key);
+
             string tempFile = Path.GetTempFileName();
 
             using (FileStream inputStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
@@ -87,7 +89,6 @@ namespace FileEncryption
 
                 while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) > 0)
                 {
-                    // Шифрування даних
                     for (int i = 0; i < bytesRead; i++)
                     {
                         buffer[i] ^= keyBytes[i % keyBytes.Length];
@@ -96,39 +97,6 @@ namespace FileEncryption
 
                     processedBytes += bytesRead;
                     int progressPercentage = (int)((processedBytes * 100) / totalBytes);
-                    worker.ReportProgress(progressPercentage);
-                }
-            }
-
-            File.Copy(tempFile, filePath, overwrite: true);
-            File.Delete(tempFile);
-        }
-
-        private void DecryptFile(string filePath, string key, BackgroundWorker worker)
-        {
-            byte[] keyBytes = Encoding.UTF8.GetBytes(key);
-            string tempFile = Path.GetTempFileName();
-
-            using (FileStream inputStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            using (FileStream tempStream = new FileStream(tempFile, FileMode.Create, FileAccess.Write))
-            {
-                byte[] buffer = new byte[8192];
-                long totalBytes = inputStream.Length;
-                long processedBytes = 0;
-                int bytesRead;
-
-                while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    // Дешифрування даних
-                    for (int i = 0; i < bytesRead; i++)
-                    {
-                        buffer[i] ^= keyBytes[i % keyBytes.Length];
-                    }
-                    tempStream.Write(buffer, 0, bytesRead);
-
-                    processedBytes += bytesRead;
-                    int progressPercentage = (int)((processedBytes * 100) / totalBytes);
-                    worker.ReportProgress(progressPercentage);
                 }
             }
 
@@ -138,14 +106,7 @@ namespace FileEncryption
 
         private void BgWorker_DoWork(object sender, DoWorkEventArgs e)
         {
-            if (isEncoding)
-            {
-                EncryptFile(currentFilePath, currentKey, (BackgroundWorker)sender);
-            }
-            else
-            {
-                DecryptFile(currentFilePath, currentKey, (BackgroundWorker)sender);
-            }
+            EncryptOrDecryptFile(currentFilePath, currentKey, (BackgroundWorker)sender);
         }
 
 

--- a/FileEncryption/Form1.cs
+++ b/FileEncryption/Form1.cs
@@ -1,23 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.IO;
 
 namespace FileEncryption
 {
     public partial class Form1 : Form
     {
-        private BackgroundWorker bgWorker = new BackgroundWorker();
-
         private string currentFilePath;
         private string currentKey;
-
         private bool isEncoding;
 
         private DateTime startTime;
@@ -27,13 +19,9 @@ namespace FileEncryption
         public Form1()
         {
             InitializeComponent();
-            bgWorker.WorkerReportsProgress = true;
-            bgWorker.DoWork += BgWorker_DoWork;
-            bgWorker.ProgressChanged += BgWorker_ProgressChanged;
-            bgWorker.RunWorkerCompleted += BgWorker_RunWorkerCompleted;
         }
 
-        private void StartFileOperation(string filePath, string key, bool encoding)
+        private async void StartFileOperation(string filePath, string key, bool encoding)
         {
             if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(key))
             {
@@ -49,7 +37,21 @@ namespace FileEncryption
             startTime = DateTime.Now;
             timer.Start();
 
-            bgWorker.RunWorkerAsync();
+            var progress = new Progress<int>(percent => progressBar.Value = percent);
+
+            try
+            {
+                await EncryptOrDecryptFileAsync(currentFilePath, currentKey, progress);
+                timer.Stop();
+                elapsedTime = DateTime.Now - startTime;
+
+                string operation = isEncoding ? "зашифровано" : "дешифровано";
+                MessageBox.Show($"Файл успішно {operation}: {currentFilePath}\nЧас виконання: {elapsedTime.TotalSeconds:F2} секунд.", "Готово", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Сталася помилка: {ex.Message}", "Помилка", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
 
         private void btn_encoding_Click(object sender, EventArgs e)
@@ -66,10 +68,9 @@ namespace FileEncryption
             StartFileOperation(filePath, key, false);
         }
 
-        private void EncryptOrDecryptFile(string filePath, string key, BackgroundWorker worker)
+        private async Task EncryptOrDecryptFileAsync(string filePath, string key, IProgress<int> progress)
         {
             byte[] keyBytes = Encoding.UTF8.GetBytes(key);
-
             string tempFile = Path.GetTempFileName();
 
             using (FileStream inputStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
@@ -80,16 +81,18 @@ namespace FileEncryption
                 long processedBytes = 0;
                 int bytesRead;
 
-                while ((bytesRead = inputStream.Read(buffer, 0, buffer.Length)) > 0)
+                while ((bytesRead = await inputStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
                 {
                     for (int i = 0; i < bytesRead; i++)
                     {
                         buffer[i] ^= keyBytes[i % keyBytes.Length];
                     }
-                    tempStream.Write(buffer, 0, bytesRead);
+
+                    await tempStream.WriteAsync(buffer, 0, bytesRead);
 
                     processedBytes += bytesRead;
                     int progressPercentage = (int)((processedBytes * 100) / totalBytes);
+                    progress.Report(progressPercentage);
                 }
             }
 
@@ -97,28 +100,13 @@ namespace FileEncryption
             File.Delete(tempFile);
         }
 
-        private void BgWorker_DoWork(object sender, DoWorkEventArgs e)
-        {
-            EncryptOrDecryptFile(currentFilePath, currentKey, (BackgroundWorker)sender);
-        }
 
-
-        private void BgWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
-        {
-            progressBar.Value = e.ProgressPercentage;
-        }
-
-        private void BgWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
-        {
-            timer.Stop();
-            elapsedTime = DateTime.Now - startTime;
-            string operation = isEncoding ? "зашифровано" : "дешифровано";
-            MessageBox.Show($"Файл успішно {operation}: {currentFilePath}\nЧас виконання: {elapsedTime.TotalSeconds:F2} секунд.", "Готово", MessageBoxButtons.OK, MessageBoxIcon.Information);
-        }
         private string ChooseFile()
         {
-            var dlg = new OpenFileDialog();
-            dlg.Filter = "Text Files|*.txt;*.doc;*.docx;*.xls;*.xlsx|All Files|*.*";
+            var dlg = new OpenFileDialog
+            {
+                Filter = "Text Files|*.txt;*.doc;*.docx;*.xls;*.xlsx|All Files|*.*"
+            };
             return dlg.ShowDialog() == DialogResult.OK ? dlg.FileName : null;
         }
 

--- a/FileEncryption/Form1.cs
+++ b/FileEncryption/Form1.cs
@@ -33,44 +33,37 @@ namespace FileEncryption
             bgWorker.RunWorkerCompleted += BgWorker_RunWorkerCompleted;
         }
 
-        private void btn_encoding_Click(object sender, EventArgs e)
+        private void StartFileOperation(string filePath, string key, bool encoding)
         {
-            if (string.IsNullOrEmpty(tb_4FileEncoding.Text) || string.IsNullOrEmpty(tb_keyEncoding.Text))
+            if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(key))
             {
-                MessageBox.Show("Будь ласка, виберіть файл і введіть ключ.", "Помилка", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("Будь ласка, виберіть файл та введіть ключ.", "Помилка", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            currentFilePath = tb_4FileEncoding.Text;
-            currentKey = tb_keyEncoding.Text;
-            isEncoding = true;
+            currentFilePath = filePath;
+            currentKey = key;
+            isEncoding = encoding;
 
             progressBar.Value = 0;
-
             startTime = DateTime.Now;
             timer.Start();
 
             bgWorker.RunWorkerAsync();
         }
 
+        private void btn_encoding_Click(object sender, EventArgs e)
+        {
+            string filePath = tb_4FileEncoding.Text;
+            string key = tb_keyEncoding.Text;
+            StartFileOperation(filePath, key, true);
+        }
+
         private void btn_decoding_Click(object sender, EventArgs e)
         {
-            if (string.IsNullOrEmpty(tb_4FileDecoding.Text) || string.IsNullOrEmpty(tb_keyDecoding.Text))
-            {
-                MessageBox.Show("Будь ласка, виберіть файл та введіть ключ.", "Помилка", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
-            }
-
-            currentFilePath = tb_4FileDecoding.Text;
-            currentKey = tb_keyDecoding.Text;
-            isEncoding = false;
-
-            progressBar.Value = 0;
-
-            startTime = DateTime.Now;
-            timer.Start();
-
-            bgWorker.RunWorkerAsync();
+            string filePath = tb_4FileDecoding.Text;
+            string key = tb_keyDecoding.Text;
+            StartFileOperation(filePath, key, false);
         }
 
         private void EncryptOrDecryptFile(string filePath, string key, BackgroundWorker worker)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+#FileEncryption


### PR DESCRIPTION
This PR refactors the StartFileOperation method by breaking it into smaller, single-responsibility methods. This improves code readability, maintainability, and reusability.

Closes #15 